### PR TITLE
Fix verify target

### DIFF
--- a/traffic_router/core/src/main/java/org/apache/traffic_control/traffic_router/core/util/Fetcher.java
+++ b/traffic_router/core/src/main/java/org/apache/traffic_control/traffic_router/core/util/Fetcher.java
@@ -134,7 +134,16 @@ public class Fetcher {
 			connection.connect();
 
 		} catch (Exception e) {
-			LOGGER.error("Failed Http Request to " + http.getURL() + " Status " + http.getResponseCode());
+			String responseCode = "(none)";
+			try {
+				responseCode = String.valueOf(http.getResponseCode());
+
+			} catch (IOException e2) {
+				// Don't care
+				LOGGER.info("Exception during call attempt to http.getResponseCode()");
+			}
+
+			LOGGER.error("Failed Http Request to " + http.getURL() + " Status " + responseCode);
 			http.disconnect();
 		}
 

--- a/traffic_router/core/src/test/java/org/apache/traffic_control/traffic_router/core/TestBase.java
+++ b/traffic_router/core/src/test/java/org/apache/traffic_control/traffic_router/core/TestBase.java
@@ -27,6 +27,7 @@ import org.apache.logging.log4j.Logger;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.FileSystemXmlApplicationContext;
 
+import javax.management.InstanceAlreadyExistsException;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 import java.io.File;
@@ -121,7 +122,7 @@ public class TestBase {
 			e.printStackTrace();
 		}
 
-		ConsoleAppender consoleAppender = ConsoleAppender.newBuilder().setLayout(PatternLayout.newBuilder().withPattern("%d{ISO8601} [%-5p] %c{4}: %m%n").build()).build();
+		ConsoleAppender consoleAppender = ConsoleAppender.newBuilder().setName("TestBase").setLayout(PatternLayout.newBuilder().withPattern("%d{ISO8601} [%-5p] %c{4}: %m%n").build()).build();
 		LoggerContext.getContext().getRootLogger().addAppender(consoleAppender);
 		LoggerContext.getContext().getRootLogger().setLevel(Level.INFO);
 	}
@@ -139,6 +140,13 @@ public class TestBase {
 	public static void tearDownFakeServers() throws Exception {
 		httpDataServer.stop();
 		tmpDeployDir.deleteOnExit();
+		final MBeanServer platformMBeanServer = ManagementFactory.getPlatformMBeanServer();
+		try {
+			final ObjectName objectName = new ObjectName(DeliveryServiceCertificatesMBean.OBJECT_NAME);
+			platformMBeanServer.unregisterMBean(objectName);
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
 	}
 
 	public static ApplicationContext getContext() {

--- a/traffic_router/core/src/test/java/org/apache/traffic_control/traffic_router/core/TrafficRouterStart.java
+++ b/traffic_router/core/src/test/java/org/apache/traffic_control/traffic_router/core/TrafficRouterStart.java
@@ -39,7 +39,7 @@ public class TrafficRouterStart {
 
 		LoggerContext.getContext().getLogger("org.springframework").setLevel(Level.WARN);
 
-		ConsoleAppender consoleAppender = ConsoleAppender.newBuilder().setLayout(PatternLayout.newBuilder().withPattern("%d{ISO8601} [%-5p] %c{4}: %m%n").build()).build();
+		ConsoleAppender consoleAppender = ConsoleAppender.newBuilder().setName("TrafficRouterStart").setLayout(PatternLayout.newBuilder().withPattern("%d{ISO8601} [%-5p] %c{4}: %m%n").build()).build();
 		LoggerContext.getContext().getRootLogger().addAppender(consoleAppender);
 		LoggerContext.getContext().getRootLogger().setLevel(Level.INFO);
 

--- a/traffic_router/core/src/test/java/org/apache/traffic_control/traffic_router/core/dns/ZoneManagerTest.java
+++ b/traffic_router/core/src/test/java/org/apache/traffic_control/traffic_router/core/dns/ZoneManagerTest.java
@@ -72,7 +72,7 @@ public class ZoneManagerTest {
 	public void setUp() throws Exception {
 		trafficRouterManager = (TrafficRouterManager) context.getBean("trafficRouterManager");
 		trafficRouterManager.getTrafficRouter().setApplicationContext(context);
-		final File file = new File("src/test/db/czmap.json");
+		final File file = new File("src/test/resources/czmap.json");
 		final ObjectMapper mapper = new ObjectMapper();
 		final JsonNode jsonNode = mapper.readTree(file);
 		final JsonNode coverageZones = jsonNode.get("coverageZones");

--- a/traffic_router/core/src/test/java/org/apache/traffic_control/traffic_router/core/external/ExternalTestSuite.java
+++ b/traffic_router/core/src/test/java/org/apache/traffic_control/traffic_router/core/external/ExternalTestSuite.java
@@ -141,7 +141,7 @@ public class ExternalTestSuite {
 		LoggerContext.getContext().getLogger("org.eclipse.jetty").setLevel(Level.WARN);
 		LoggerContext.getContext().getLogger("org.springframework").setLevel(Level.WARN);
 
-		ConsoleAppender consoleAppender = ConsoleAppender.newBuilder().setLayout(PatternLayout.newBuilder().withPattern("%d{ISO8601} [%-5p] %c{4}: %m%n").build()).build();
+		ConsoleAppender consoleAppender = ConsoleAppender.newBuilder().setName("ExternalTestSuite").setLayout(PatternLayout.newBuilder().withPattern("%d{ISO8601} [%-5p] %c{4}: %m%n").build()).build();
 		LoggerContext.getContext().getRootLogger().addAppender(consoleAppender);
 		LoggerContext.getContext().getRootLogger().setLevel(Level.INFO);
 

--- a/traffic_router/core/src/test/java/org/apache/traffic_control/traffic_router/core/router/TrafficRouterTest.java
+++ b/traffic_router/core/src/test/java/org/apache/traffic_control/traffic_router/core/router/TrafficRouterTest.java
@@ -73,6 +73,7 @@ public class TrafficRouterTest {
         when(deliveryService.isCoverageZoneOnly()).thenReturn(false);
         when(deliveryService.getDispersion()).thenReturn(mock(Dispersion.class));
         when(deliveryService.isAcceptHttp()).thenReturn(true);
+		when(deliveryService.getId()).thenReturn("someDsName");
 
         consistentHasher = mock(ConsistentHasher.class);
 
@@ -126,6 +127,9 @@ public class TrafficRouterTest {
         HTTPRequest httpRequest = new HTTPRequest();
         httpRequest.setClientIP("192.168.10.11");
         httpRequest.setHostname("ccr.example.com");
+		Map<String, String> headers = new HashMap<String, String>();
+		headers.put("x-tc-steering-option", "itCreatesHttpResults");
+		httpRequest.setHeaders(headers);
 
         Track track = spy(StatTracker.getTrack());
 
@@ -162,6 +166,8 @@ public class TrafficRouterTest {
     public void itFiltersByIPAvailability() throws Exception {
 
         DeliveryService ds = mock(DeliveryService.class);
+
+		when(ds.getId()).thenReturn("itFiltersByIpAvailable");
 
         Cache cacheIPv4 = mock(Cache.class);
         when(cacheIPv4.hasDeliveryService(any())).thenReturn(true);
@@ -280,6 +286,9 @@ public class TrafficRouterTest {
         httpRequest.setClientIP("192.168.10.11");
         httpRequest.setHostname("ccr.example.com");
         httpRequest.setPath("/some/path");
+		Map<String, String> headers = new HashMap<String, String>();
+		headers.put("x-tc-steering-option", "itSetsResultToGeo");
+		httpRequest.setHeaders(headers);
 
         Track track = spy(StatTracker.getTrack());
 

--- a/traffic_router/core/src/test/java/org/apache/traffic_control/traffic_router/core/util/FetcherTest.java
+++ b/traffic_router/core/src/test/java/org/apache/traffic_control/traffic_router/core/util/FetcherTest.java
@@ -21,12 +21,19 @@ import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.lang.ClassCastException;
 import java.net.HttpURLConnection;
+import java.net.SocketTimeoutException;
 import java.net.URL;
+import java.net.URLConnection;
 
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.method;
 import static org.powermock.api.mockito.PowerMockito.mock;
@@ -61,5 +68,45 @@ public class FetcherTest {
         Fetcher fetcher = new Fetcher();
         fetcher.fetchIfModifiedSince("http://www.example.com", 123456L);
         verify(httpURLConnection).setIfModifiedSince(123456L);
+    }
+
+    @Test
+    public void itChecksIfSocketTimeoutExceptionThrown() throws Exception {
+		// Test that an IOException (ex connection-failure) is caught, re-thrown, and
+		// that the embedded error is correctly encapsulated in the exception
+		//
+		final String mockedException = "Mocked Connection Failure";
+        URL url = mock(URL.class);
+        HttpURLConnection httpURLConnection = mock(HttpURLConnection.class);
+
+        stub(method(URL.class, "openConnection")).toReturn(httpURLConnection);
+		doThrow(new SocketTimeoutException(mockedException)).when(httpURLConnection).connect();
+        whenNew(URL.class).withArguments("http://www.example.com").thenReturn(url);
+
+        Fetcher fetcher = new Fetcher();
+		try {
+			fetcher.fetchIfModifiedSince("http://www.example.com", 123456L);
+			assertTrue(false);
+		} catch (SocketTimeoutException e) {
+			assertEquals(e.toString(), "java.net.SocketTimeoutException: " + mockedException);
+		}
+    }
+
+    @Test
+    public void itChecksIfOtherThrown() throws Exception {
+		// Test that other exceptions (ex CastClassException) is caught and
+		// squelched. This matches existing functionality.
+		//
+		// This test relies on the CastClassException which is thrown when "connection"
+		// is cast to type "HttpURLConnection". This will abort execution of
+		// Fetcher::getConnection() during the cast of "connection" to "http". This will
+		// result in the callstack unwinding normally with null return codes.
+		//
+        URLConnection urlConnection = mock(URLConnection.class);
+        stub(method(URL.class, "openConnection")).toReturn(urlConnection);
+
+        URL url = mock(URL.class);
+        Fetcher fetcher = new Fetcher();
+		assertEquals(fetcher.fetchIfModifiedSince("http://www.example.com", 123456L), null);
     }
 }

--- a/traffic_router/core/src/test/resources/publish/CrConfig.json
+++ b/traffic_router/core/src/test/resources/publish/CrConfig.json
@@ -1918,6 +1918,8 @@
   "config": {
     "certificate.api.url": "http://${toHostname}/api/2.0/cdns/name/${cdnName}/sslkeys",
     "client.steering.forced.diversity": "true",
+    "dnschallengemapping.polling.url": "http://${toHostname}/api/2.0/dnsrecords/",
+    "dnschallengemapping.polling.interval": "600000",
     "federationmapping.polling.url": "http://${toHostname}/api/2.0/federations/all",
     "federationmapping.polling.interval": "600000",
     "steeringmapping.polling.url": "http://${toHostname}/api/2.0/steering",

--- a/traffic_router/core/src/test/resources/publish/CrConfig2.json
+++ b/traffic_router/core/src/test/resources/publish/CrConfig2.json
@@ -1210,8 +1210,10 @@
     }
   },
   "config": {
-    "federationmapping.polling.url": "http://${toHostname}/api/2.0/federations/all",
     "certificate.api.url": "http://${toHostname}/api/2.0/cdns/name/${cdnName}/sslkeys",
+    "dnschallengemapping.polling.url": "http://${toHostname}/api/2.0/dnsrecords/",
+    "dnschallengemapping.polling.interval": "600000",
+    "federationmapping.polling.url": "http://${toHostname}/api/2.0/federations/all",
     "federationmapping.polling.interval": "600000",
     "steeringmapping.polling.url": "http://${toHostname}/api/2.0/steering",
     "steeringmapping.polling.interval": "15000",

--- a/traffic_router/core/src/test/resources/publish/CrConfig3.json
+++ b/traffic_router/core/src/test/resources/publish/CrConfig3.json
@@ -1210,8 +1210,10 @@
     }
   },
   "config": {
-    "federationmapping.polling.url": "http://${toHostname}/api/2.0/federations/all",
     "certificate.api.url": "http://${toHostname}/api/2.0/cdns/name/${cdnName}/sslkeys",
+    "dnschallengemapping.polling.url": "http://${toHostname}/api/2.0/dnsrecords/",
+    "dnschallengemapping.polling.interval": "600000",
+    "federationmapping.polling.url": "http://${toHostname}/api/2.0/federations/all",
     "federationmapping.polling.interval": "600000",
     "steeringmapping.polling.url": "http://${toHostname}/api/2.0/steering",
     "steeringmapping.polling.interval": "15000",

--- a/traffic_router/core/src/test/resources/publish/CrConfig4.json
+++ b/traffic_router/core/src/test/resources/publish/CrConfig4.json
@@ -1255,8 +1255,10 @@
     }
   },
   "config": {
-    "federationmapping.polling.url": "http://${toHostname}/api/2.0/federations/all",
     "certificate.api.url": "http://${toHostname}/api/2.0/cdns/name/${cdnName}/sslkeys",
+    "dnschallengemapping.polling.url": "http://${toHostname}/api/2.0/dnsrecords/",
+    "dnschallengemapping.polling.interval": "600000",
+    "federationmapping.polling.url": "http://${toHostname}/api/2.0/federations/all",
     "federationmapping.polling.interval": "600000",
     "steeringmapping.polling.url": "http://${toHostname}/api/2.0/steering",
     "steeringmapping.polling.interval": "15000",


### PR DESCRIPTION
<!--
Thank you for contributing! Please be sure to read our contribution guidelines: https://github.com/apache/trafficcontrol/blob/master/CONTRIBUTING.md
If this closes or relates to an existing issue, please reference it using one of the following:

Closes: #ISSUE
Related: #ISSUE

If this PR fixes a security vulnerability, DO NOT submit! Instead, contact
the Apache Traffic Control Security Team at security@trafficcontrol.apache.org and follow the
guidelines at https://apache.org/security regarding vulnerability disclosure.
-->


<!-- **^ Add meaningful description above** --><hr/>
This PR includes changes for the following issues:

:: Race condition between certificate-file and CrConfig-file upload and activation that can result in incorrect promotion of a CrConfig. The current logical flow has the two files arriving asynchronously from one another. When the ConfigHandler has ingested the new DeliveryServices it forwards the new information to the CertificatePublisher and then pends until the CP has OK'd the DS.  The certificates are uploaded periodically so the DS will be verified when the next certificate file upload. Since the actions are asynchronous the verification process may start just before the ConfigHandler pushes the new set of DS and then pends - in this case the CP is verifying against the old/unupdated set of DS. When validation completes the CP will clear the pend-lock that clears the _new_ CrConfig to be accepted as a valid snapshot - the new DS were never validated. This was exposed during the integration test external/RouterTest.java in RouterTest::itRejectsCrConfigWithMissingCert. This (partial) fix was to introduce a flag in CertificatesPublisher which latches when the new DS has been received. If/When the CertificatesPublisher exits certificatesValidation it will not clear the pend-lock if the DS have been updated while validation was in progress - validation will be done at the next file upload. There still exists a small window in which this failure can still occur but the vulnerability is greatly reduced - likely below a point in which it's likely to happen in the wild.
./core/src/main/java/org/apache/traffic_control/traffic_router/core/secure/CertificatesPublisher.java


:: Uncaught exception in Fetcher.java that results in a bogus exception being thrown upward. If/When the connection fails during Fetcher::getConnection() than the catch-block will be executed. During execution the LOGGER will attempt to call http;getResponseCode(), which will throw an IOException because the remote server cannot be reached. This second exception is then propagated upward, and is currently caught by the ultimate author of the original request (usually through Fetcher::getIfModifiedSince() or Fetcher::fetchIfModifiedSince()). The result is a semi-bogus exception being reported to the penultimate caller. A minor adjustment has been made to Fetcher.java to intercept this second exception, discard it, and re-throw the original exception. Only IOExceptions are allowed to be rethrown in order to avoid adding new/untested functionality to the logical blocks that depend on Fetcher.
./core/src/main/java/org/apache/traffic_control/traffic_router/core/util/Fetcher.java

:: ConsoleAppender now requires a name in order to be constructed. A number of test-files depend on a log4j::ConsoleAppender, lacking a setName call construction aborts. This problem was hamstringing a number of the integration tests being run during the maven verify target run. ./core/src/test/java/org/apache/traffic_control/traffic_router/core/TestBase.java
./core/src/test/java/org/apache/traffic_control/traffic_router/core/TrafficRouterStart.java
./core/src/test/java/org/apache/traffic_control/traffic_router/core/external/ExternalTestSuite.java

:: During verify execution a number of pedantic stack traces are thrown when the Fake Server is started. The stack-track is thrown from TestBase itself when the platformMBeanServer (re)registers the DeliveryServiceCertificatesMBean. Added code to un-register this bean when the Fake Server is shut down.
./core/src/test/java/org/apache/traffic_control/traffic_router/core/TestBase.java

:: Changed the path for the czmap.json file. This file was located under ./core/src/test/resources/czmap.json alongside other files used during testing - but the path in the test file was ./core/src/test/db/czmap.json. It seems like this particular path was never updated when the file was moved.
./core/src/test/java/org/apache/traffic_control/traffic_router/core/dns/ZoneManagerTest.java

:: Monkeyed with HttpDataServer to generate ContentLength. Down in the bowels of the HttpURLConnection there's a check for Content-Length which is supposedly a "should" in the http spec. The HttpDataServer was leaving the x-fer length at 0, which was generating a chunked transfer. This was causing a little bit of churn in the logical flow during debugging. To clean this up the HttpDataServer now provides the Content-Length header during most transfers.
./core/src/test/java/org/apache/traffic_control/traffic_router/core/external/HttpDataServer.java

:: During debugging noted that the TrafficRouterTest.java was silently throwing some NPE's. Fixes have been added to more-completely populate the test setup to avoid these issues and provide better test coverage.
./core/src/test/java/org/apache/traffic_control/traffic_router/core/router/TrafficRouterTest.java

:: Added new tests to FetcherTest.java to verify coverage of exception cases
./core/src/test/java/org/apache/traffic_control/traffic_router/core/util/FetcherTest.java

:: During execution of the integration test RouterTest::itRejectsCrConfigWithMissingCert it was noted that execution would reliably hangup - further tests weren't executed. Additionally, the RouterTest was periodically failing. Debugging showed that something was happening when the dnsrecords were being refresher. It turns out that the dnschallengemapping.polling.url had not been changed in the CrConfig files used in integration tests, resulting in the dnsrecords fetch using an https address. Since the HttpDataServer is only setup for http service, these https connection attempts were failing after a timeout. Two things were happening. First, since the HttpDataServer only opened one-port/one-listener, the https attempt was tying up the test port, which was blocking the other fetches required for testing, throwing off test timing (what was happening in the RouterTest). Second, the connection failure was generating an uncaught exception in Fetcher::getConnection which was leaving the TCP connection in limbo, probably in a TIMEDWAIT state which would eventually give up - but long after the tests had failed. The earlier fix for the uncaught exception in Fetcher::getConnection fixes the second part, but since the dnsrecords aren't critical for the integration tests it was also helpful to just shove them out of the way. The CrConfig files have been updated to include adjustments for the dnsrecords url and fetch timeout to move them out of the way of the integration tests.
./core/src/test/resources/publish/CrConfig.json
./core/src/test/resources/publish/CrConfig2.json
./core/src/test/resources/publish/CrConfig3.json
./core/src/test/resources/publish/CrConfig4.json



## Which Traffic Control components are affected by this PR?
<!-- Please delete all components from this list that are NOT affected by this PR.
Feel free to add the name of a tool or script that is affected but not on the list.
-->
- Traffic Router

## What is the best way to verify this PR?
<!-- Please include here ALL the steps necessary to test your PR.
If your PR has tests (and most should), provide the steps needed to run the tests.
If not, please provide step-by-step instructions to test the PR manually and explain why your PR does not need tests. -->
Best way - run 'mvn verify'

## If this is a bugfix, which Traffic Control versions contained the bug?
<!-- Delete this section if the PR is not a bugfix, or if the bug is only in the master branch.
Examples:
- 5.1.2
- 5.1.3 (RC1)
 -->
This PR doesn't contain a specific bugfix as its bundles a number of changes related to smaller issues into one batch-commit.


## PR submission checklist
- [x] This PR has tests <!-- If not, please delete this text and explain why this PR does not need tests. -->
- [x] This PR has documentation <!-- If not, please delete this text and explain why this PR does not need documentation. -->
- [x] This PR has a CHANGELOG.md entry <!-- A fix for a bug from an ATC release, an improvement, or a new feature should have a changelog entry. -->
- [x] This PR **DOES NOT FIX A SERIOUS SECURITY VULNERABILITY** (see [the Apache Software Foundation's security guidelines](https://apache.org/security) for details)

<!--
Licensed to the Apache Software Foundation (ASF) under one
or more contributor license agreements.  See the NOTICE file
distributed with this work for additional information
regarding copyright ownership.  The ASF licenses this file
to you under the Apache License, Version 2.0 (the
"License"); you may not use this file except in compliance
with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing,
software distributed under the License is distributed on an
"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
KIND, either express or implied.  See the License for the
specific language governing permissions and limitations
under the License.
-->
